### PR TITLE
Bug Fix: No spinner displayed after dialog closed

### DIFF
--- a/script
+++ b/script
@@ -73,6 +73,7 @@ fun refresh_callback() {
         spinner.index += 1;
         spinner.index %= spinner.imagecount;
         spinner.sprite.SetImage(rotate_image(spinner.index));
+        spinner.sprite.SetOpacity(1);
     }
 }
 


### PR DESCRIPTION
This addresses the following issue:
After the dialog is closed (luks password entered) there is no spinner is it is still set to opacity `0`. With this change. the moment the password is entered and the `refresh_callback` is invoked the spinner opacity is restored to `1`.